### PR TITLE
Fix incorrect score output

### DIFF
--- a/gamemanager.cpp
+++ b/gamemanager.cpp
@@ -161,10 +161,10 @@ void GameManager::endRound()
             qInfo().noquote().nospace()
                      << "name:" << player->name()
                      << ";wins:" << player->wins()
-                     << ";score:" << player->points();
+                     << ";score:" << player->totalPoints();
             scoreFile.write(player->name().toUtf8() + ' ' +
                             QByteArray::number(player->wins()) + ' ' +
-                            QByteArray::number(player->points()));
+                            QByteArray::number(player->totalPoints()));
         }
     }
 }

--- a/player.cpp
+++ b/player.cpp
@@ -15,6 +15,7 @@ Player::Player(QObject *parent, int id, NetworkClient *networkClient) : QObject(
     m_x(0),
     m_y(0),
     m_points(0),
+    m_totalPoints(0),
     m_networkClient(networkClient),
     m_power(NoPower),
     m_powerLeft(0)
@@ -96,6 +97,7 @@ int Player::takePoints()
 {
     const int points = m_points;
     m_points = 0;
+    m_totalPoints -= points;
     emit pointsChanged();
     return points;
 }

--- a/player.h
+++ b/player.h
@@ -48,8 +48,9 @@ public:
 
     NetworkClient *networkClient() { return m_networkClient; }
 
-    void addPoints(int points) { m_points += points; emit pointsChanged();}
+    void addPoints(int points) { m_points += points; m_totalPoints += points; emit pointsChanged();}
     int points() const { return m_points; }
+    int totalPoints() const { return m_totalPoints; }
     int takePoints();
     void resetPlayer();
 
@@ -110,6 +111,7 @@ private:
     int m_y;
 
     int m_points;
+    int m_totalPoints;
 
     NetworkClient *m_networkClient;
     Power m_power;


### PR DESCRIPTION
Will now accumulate the score over all turns and report that to stdout and scores.txt instead of it being the score for the last round.

It currently works like wins, in that it never resets. Maybe both wins and total score should be reset when starting a new game?